### PR TITLE
Update io.github.pemsley.coot.yaml

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -318,7 +318,6 @@ modules:
     config-opts:
       - --with-boost-libdir=/app/lib
       - --with-rdkit-prefix=/app
-      - --with-enhanced-ligand-tools
       - --with-guile
       - --with-backward
       - --with-libdw


### PR DESCRIPTION
- Deleted  `--with-enhanced-ligand-tools`  to configure Coot