### PR TITLE
Bump up to `cd71894`  for coot module

### DIFF
--- a/deps/pypi-dependencies.json
+++ b/deps/pypi-dependencies.json
@@ -4,6 +4,20 @@
     "build-commands": [],
     "modules": [
         {
+            "name": "python3-markupsafe",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"markupsafe\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz",
+                    "sha256": "ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0"
+                }
+            ]
+        },
+        {
             "name": "python3-meson-python",
             "buildsystem": "simple",
             "build-commands": [
@@ -22,8 +36,22 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/e8/61/9dd3e68d2b6aa40a5fc678662919be3c3a7bf22cba5a6b4437619b77e156/pyproject_metadata-0.9.0-py3-none-any.whl",
-                    "sha256": "fc862aab066a2e87734333293b0af5845fe8ac6cb69c451a41551001e923be0b"
+                    "url": "https://files.pythonhosted.org/packages/7e/b1/8e63033b259e0a4e40dd1ec4a9fee17718016845048b43a36ec67d62e6fe/pyproject_metadata-0.9.1-py3-none-any.whl",
+                    "sha256": "ee5efde548c3ed9b75a354fc319d5afd25e9585fa918a34f62f904cc731973ad"
+                }
+            ]
+        },
+        {
+            "name": "python3-nanobind",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"nanobind\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/8e/9e/dadc3831f40e22c1b3925f07894646ada7906ef5b48db5c5eb2b03ca9faa/nanobind-2.5.0-py3-none-any.whl",
+                    "sha256": "e1e5c816e5d10f0b252d82ba7f769f0f6679f5e043cf406aec3d9e184bf2a60d"
                 }
             ]
         },
@@ -38,20 +66,6 @@
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz",
                     "sha256": "2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010"
-                }
-            ]
-        },
-        {
-            "name": "python3-markupsafe",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"markupsafe\" --no-build-isolation"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz",
-                    "sha256": "ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0"
                 }
             ]
         }

--- a/deps/pypi-dependencies.sh
+++ b/deps/pypi-dependencies.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-./flatpak-builder-tools/pip/flatpak-pip-generator --runtime='org.gnome.Sdk//47' --requirements-file='requirements.txt' --output pypi-dependencies
+./flatpak-builder-tools/pip/flatpak-pip-generator --runtime='org.gnome.Sdk//48' --requirements-file='requirements.txt' --output pypi-dependencies

--- a/deps/requirements.txt
+++ b/deps/requirements.txt
@@ -1,5 +1,6 @@
-meson-python
-numpy==1.26.4
 mako
 markdown
 markupsafe
+meson-python
+nanobind
+numpy==1.26.4

--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -1,6 +1,6 @@
 app-id: io.github.pemsley.coot
 runtime: org.gnome.Platform
-runtime-version: "47"
+runtime-version: "48"  # include python 3.12.9
 sdk: org.gnome.Sdk
 command: coot
 finish-args:
@@ -136,7 +136,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/boostorg/boost.git
-        tag: boost-1.86.0
+        tag: boost-1.87.0
 
   - name: libdwarf
     buildsystem: autotools
@@ -237,10 +237,13 @@ modules:
 
   - name: gemmi
     buildsystem: cmake-ninja
+    config-opts:
+      - -DUSE_PYTHON=1
+      - -DPYTHON_INSTALL_DIR=/app/lib/python3.12/site-packages
     sources:
       - type: git
         url: https://github.com/project-gemmi/gemmi.git
-        commit: 122048f755839a536c186e519387f7617b76a7bf
+        commit: b01123ef241cd7f8e03c7ae2e412081032222799
 
   - name: swig
     buildsystem: autotools
@@ -281,7 +284,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/rdkit/rdkit
-        tag: Release_2024_09_4
+        tag: Release_2024_09_5
       - type: archive
         url: https://github.com/schrodinger/maeparser/archive/refs/tags/v1.3.1.tar.gz
         sha256: a8d80f67d1b9be6e23b9651cb747f4a3200132e7d878a285119c86bf44568e36
@@ -339,7 +342,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        commit: 835c5ebde36c6aa2d25104f4ad651fe5aa42f291
+        tag: Release-1.1.14
       - type: archive
         url: https://github.com/MonomerLibrary/monomers/archive/refs/tags/ccp4-9.0.006.tar.gz
         sha256: 3143b3aba958f370956961f2c78b70acb8e94f840a3aee7beb9f2668253153b4

--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -342,7 +342,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        tag: Release-1.1.14
+        commit: cd71894df3e97c4eafbed298636febedbb0858d9
       - type: archive
         url: https://github.com/MonomerLibrary/monomers/archive/refs/tags/ccp4-9.0.006.tar.gz
         sha256: 3143b3aba958f370956961f2c78b70acb8e94f840a3aee7beb9f2668253153b4


### PR DESCRIPTION
This pull request includes several updates to dependencies and configurations in the project. The most important changes include updating subproject commits, modifying dependencies in `pypi-dependencies.json`, updating the runtime version in various files, and changing module configurations in `io.github.pemsley.coot.yaml`.
This pull request includes several updates to dependencies and configurations in various files. The most important changes include updating submodule commits, adding new dependencies, and updating existing dependencies and their versions.

Dependency updates:

* [`deps/flatpak-builder-tools`](diffhunk://#diff-87dc953a8acc3d59e2f188d91e89eff6b0c46842ff5cde9a4fd22f61db67bb2eL1-R1): Updated subproject commit to `aac65cf44cd4e008594a9d9ac1db08e2025067a6`.
* [`deps/pypi-dependencies.json`](diffhunk://#diff-b396deff21a365acd9245f182c176c42d53044b13a845d06c708f0aa6ac526a2R6-R19): Added `python3-markupsafe` and updated `pyproject_metadata` to version 0.9.1. Replaced `python3-numpy` with `python3-nanobind` and vice versa. [[1]](diffhunk://#diff-b396deff21a365acd9245f182c176c42d53044b13a845d06c708f0aa6ac526a2R6-R19) [[2]](diffhunk://#diff-b396deff21a365acd9245f182c176c42d53044b13a845d06c708f0aa6ac526a2L25-R68)
* [`deps/pypi-dependencies.sh`](diffhunk://#diff-3a22f7f7ddf047fa57cca47d4aebf29fc76dd99aec36d72f094dc8dd447a5a54L3-R3): Updated the runtime version to `org.gnome.Sdk//48`.
* [`deps/requirements.txt`](diffhunk://#diff-32ba8f93babbd17abf459df7b9ef623671afa7042f00bd255c50354aa4430734L1-R6): Added `nanobind` and reordered existing dependencies.

Configuration updates:

* [`io.github.pemsley.coot.yaml`](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL3-R3): Updated the runtime version to 48, updated the `boost` tag to 1.87.0, added configuration options for `gemmi`, and updated commits for `rdkit` and `coot`. [[1]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL3-R3) [[2]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL139-R139) [[3]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efR240-R246) [[4]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL284-R287) [[5]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL342-R345)
Dependency updates:

* [`deps/flatpak-builder-tools`](diffhunk://#diff-87dc953a8acc3d59e2f188d91e89eff6b0c46842ff5cde9a4fd22f61db67bb2eL1-R1): Updated subproject commit to the latest version.
* [`deps/pypi-dependencies.json`](diffhunk://#diff-b396deff21a365acd9245f182c176c42d53044b13a845d06c708f0aa6ac526a2R6-R19): Added `python3-markupsafe`, updated `pyproject_metadata` to version 0.9.1, replaced `python3-numpy` with `python3-nanobind`, and re-added `python3-numpy` with the correct version. [[1]](diffhunk://#diff-b396deff21a365acd9245f182c176c42d53044b13a845d06c708f0aa6ac526a2R6-R19) [[2]](diffhunk://#diff-b396deff21a365acd9245f182c176c42d53044b13a845d06c708f0aa6ac526a2L25-R68)
* [`deps/requirements.txt`](diffhunk://#diff-32ba8f93babbd17abf459df7b9ef623671afa7042f00bd255c50354aa4430734L1-R6): Added `nanobind` and re-ordered dependencies.

Runtime version updates:

* [`deps/pypi-dependencies.sh`](diffhunk://#diff-3a22f7f7ddf047fa57cca47d4aebf29fc76dd99aec36d72f094dc8dd447a5a54L3-R3): Updated the runtime to `org.gnome.Sdk//48`.
* [`io.github.pemsley.coot.yaml`](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL3-R3): Updated the runtime version to "48" and included Python 3.12.9.

Module configuration changes:

* [`io.github.pemsley.coot.yaml`](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL139-R139): Updated various module configurations, including changing tags and commits for `boost`, `gemmi`, `rdkit`, and `coot`. Added configuration options for `gemmi` to use Python and set the Python install directory. [[1]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL139-R139) [[2]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efR240-R246) [[3]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL284-R287) [[4]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL342-R345)Bump up to `835c5eb`… bindings