### PR TITLE
Bump to Release-1.1.15

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -342,7 +342,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        tag: Release-1.1.14
+        tag: Release-1.1.15
       - type: archive
         url: https://github.com/MonomerLibrary/monomers/archive/refs/tags/ccp4-9.0.006.tar.gz
         sha256: 3143b3aba958f370956961f2c78b70acb8e94f840a3aee7beb9f2668253153b4


### PR DESCRIPTION
This pull request includes a small change to the `io.github.pemsley.coot.yaml` file. The change updates the `tag` for the git source to `Release-1.1.15` from `Release-1.1.14`.