### PR TITLE
Merge pull request #61 from eunos-1128/beta

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -342,7 +342,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        tag: Release-1.1.15
+        commit: 6c20bc23cccc42ea55660953b804001336ff2089
       - type: archive
         url: https://github.com/MonomerLibrary/monomers/archive/refs/tags/ccp4-9.0.006.tar.gz
         sha256: 3143b3aba958f370956961f2c78b70acb8e94f840a3aee7beb9f2668253153b4

--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -342,7 +342,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        tag: Release-1.1.14
+        commit: cd71894df3e97c4eafbed298636febedbb0858d9
       - type: archive
         url: https://github.com/MonomerLibrary/monomers/archive/refs/tags/ccp4-9.0.006.tar.gz
         sha256: 3143b3aba958f370956961f2c78b70acb8e94f840a3aee7beb9f2668253153b4


### PR DESCRIPTION
This pull request updates the commit reference for the `coot` module in the `io.github.pemsley.coot.yaml` configuration file to point to a more recent commit.

* [`io.github.pemsley.coot.yaml`](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL345-R345): Updated the `coot` module's commit reference from `cd71894df3e97c4eafbed298636febedbb0858d9` to `6c20bc23cccc42ea55660953b804001336ff2089`.Bump up to `835c5eb`
This pull request includes a change to the `io.github.pemsley.coot.yaml` file to update the source reference from a specific tag to a specific commit.

* [`io.github.pemsley.coot.yaml`](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL345-R345): Updated the source reference from `tag: Release-1.1.15` to `commit: 6c20bc23cccc42ea55660953b804001336ff2089`