### PR TITLE
Update io.github.pemsley.coot.yaml

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -32,7 +32,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/project-gemmi/gemmi.git
-        tag: 0.7.1
+        tag: v0.7.1
   
   - deps/pypi-dependencies.json
 

--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -24,6 +24,16 @@ cleanup:
   - "*.a"
 
 modules:
+  - name: gemmi
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DUSE_PYTHON=1
+      - -DPYTHON_INSTALL_DIR=/app/lib/python3.12/site-packages
+    sources:
+      - type: git
+        url: https://github.com/project-gemmi/gemmi.git
+        tag: 0.7.1
+  
   - deps/pypi-dependencies.json
 
   - name: fftw2
@@ -234,16 +244,6 @@ modules:
       - type: archive
         url: https://ftp.gnu.org/gnu/guile-gnome/guile-gnome-platform/guile-gnome-platform-2.16.5.tar.gz
         sha256: 298d8c4f9b567bfe87beda18ed58d047c2e01b88c80895129de5466b921ccebe
-
-  - name: gemmi
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DUSE_PYTHON=1
-      - -DPYTHON_INSTALL_DIR=/app/lib/python3.12/site-packages
-    sources:
-      - type: git
-        url: https://github.com/project-gemmi/gemmi.git
-        commit: b01123ef241cd7f8e03c7ae2e412081032222799
 
   - name: swig
     buildsystem: autotools

--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -24,6 +24,8 @@ cleanup:
   - "*.a"
 
 modules:
+  - deps/pypi-dependencies.json
+
   - name: gemmi
     buildsystem: cmake-ninja
     config-opts:
@@ -34,8 +36,6 @@ modules:
         url: https://github.com/project-gemmi/gemmi.git
         tag: v0.7.1
   
-  - deps/pypi-dependencies.json
-
   - name: fftw2
     buildsystem: autotools
     config-opts:


### PR DESCRIPTION
This pull request involves changes to the `io.github.pemsley.coot.yaml` file, specifically related to the `cleanup` and `modules` sections. The changes primarily involve re-adding the `gemmi` module with updated details.

Changes to `cleanup`:

* Added the `gemmi` module with a `cmake-ninja` build system and configuration options for Python integration. The source is now specified with a Git URL and a tag of `0.7.1`.

Changes to `modules`:

* Removed the previous configuration of the `gemmi` module, which included a `cmake-ninja` build system and a specific commit hash for the source.- Bump gemmi version to 0.7.1