### PR TITLE
Bump to commit `d118c4` for Beta channel

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -342,7 +342,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        commit: 6c20bc23cccc42ea55660953b804001336ff2089
+        commit: d118c4049e847affe558bd4f56915f9fbcb292cb
       - type: archive
         url: https://github.com/MonomerLibrary/monomers/archive/refs/tags/ccp4-9.0.006.tar.gz
         sha256: 3143b3aba958f370956961f2c78b70acb8e94f840a3aee7beb9f2668253153b4

--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -342,7 +342,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        tag: Release-1.1.15
+        commit: 6c20bc23cccc42ea55660953b804001336ff2089
       - type: archive
         url: https://github.com/MonomerLibrary/monomers/archive/refs/tags/ccp4-9.0.006.tar.gz
         sha256: 3143b3aba958f370956961f2c78b70acb8e94f840a3aee7beb9f2668253153b4


### PR DESCRIPTION
This pull request includes a small change to the `io.github.pemsley.coot.yaml` file. The change updates the commit reference for the `coot` git source to a new commit.

* [`io.github.pemsley.coot.yaml`](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL345-R345): Updated the commit reference for the `coot` git source from `6c20bc23cccc42ea55660953b804001336ff2089` to `d118c4049e847affe558bd4f56915f9fbcb292cb`.