### PR TITLE
Update Boost to 1.88

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -146,7 +146,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/boostorg/boost.git
-        tag: boost-1.87.0
+        tag: boost-1.88.0
 
   - name: libdwarf
     buildsystem: autotools


### PR DESCRIPTION
This pull request updates the version of the Boost library used in the project. 

Dependency update:

* [`io.github.pemsley.coot.yaml`](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL149-R149): Updated the Boost library from version `boost-1.87.0` to `boost-1.88.0` in the `modules` section.