### PR TITLE
Bump to Release-1.1.16

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -331,6 +331,7 @@ modules:
         GLM_CFLAGS: "-I/app/include"
         GLM_LIBS: "-L/app/lib -lglm"
     post-install:
+      - mkdir -p ${FLATPAK_DEST}/share/coot/
       - cp -r python/ ${FLATPAK_DEST}/share/coot/
       - install -Dm644 pixmaps/icons/coot.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
       - install -Dm644 coot.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop

--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -331,9 +331,6 @@ modules:
         GLM_CFLAGS: "-I/app/include"
         GLM_LIBS: "-L/app/lib -lglm"
     post-install:
-      - mv monomers-ccp4-9.0.006 monomers
-      - mkdir -p ${FLATPAK_DEST}/share/coot/lib/data && mv monomers ${FLATPAK_DEST}/share/coot/lib/data
-      - mv reference-structures ${FLATPAK_DEST}/share/coot
       - cp -r python/ ${FLATPAK_DEST}/share/coot/
       - install -Dm644 pixmaps/icons/coot.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
       - install -Dm644 coot.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
@@ -342,12 +339,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        tag: Release-1.1.15
-      - type: archive
-        url: https://github.com/MonomerLibrary/monomers/archive/refs/tags/ccp4-9.0.006.tar.gz
-        sha256: 3143b3aba958f370956961f2c78b70acb8e94f840a3aee7beb9f2668253153b4
-        strip-components: 0
-      - type: archive
-        url: https://www2.mrc-lmb.cam.ac.uk/personal/pemsley/coot/dependencies/reference-structures.tar.gz
-        sha256: 44db38506f0f90c097d4855ad81a82a36b49cd1e3ffe7d6ee4728b15109e281a
-        strip-components: 0
+        tag: Release-1.1.16
+


### PR DESCRIPTION
This pull request updates the `io.github.pemsley.coot.yaml` file to streamline the installation process and update the source version. The most notable changes involve removing specific dependencies and updating the release tag.

### Installation process updates:
* Removed the commands for moving `monomers` and `reference-structures` directories during the post-install step, simplifying the directory structure.

### Source updates:
* Updated the `tag` in the `sources` section from `Release-1.1.15` to `Release-1.1.16`. Additionally, removed the archive sources for `monomers` and `reference-structures`, eliminating their associated URLs and SHA256 checksums.