### PR TITLE
Bump to `4f510d4` for Beta channel

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -340,5 +340,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        tag: Release-1.1.16
+        commit: 4f510d4268047175eee71692404011f0df20f056
 


### PR DESCRIPTION
This pull request updates the `io.github.pemsley.coot.yaml` file to reflect changes in dependencies and installation processes for the Coot application. Key updates include upgrading the Boost library version, removing unused archives, and simplifying the post-installation steps.

### Dependency Updates:
* Updated Boost library version from `boost-1.87.0` to `boost-1.88.0`. (`[io.github.pemsley.coot.yamlL149-R149](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL149-R149)`)
* Changed the `commit` for the Coot repository to `4f510d4268047175eee71692404011f0df20f056` and removed references to unused archives for MonomerLibrary and reference structures. (`[io.github.pemsley.coot.yamlL345-R344](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL345-R344)`)

### Installation Process Simplification:
* Removed unnecessary steps for moving `monomers` and `reference-structures` directories and simplified the creation of the `share/coot` directory. (`[io.github.pemsley.coot.yamlL334-R334](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL334-R334)`)