### PR TITLE
Bump to `21edc3a` for Beta channel

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -35,7 +35,7 @@ modules:
       - type: git
         url: https://github.com/project-gemmi/gemmi.git
         tag: v0.7.1
-  
+
   - name: fftw2
     buildsystem: autotools
     config-opts:
@@ -146,7 +146,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/boostorg/boost.git
-        tag: boost-1.88.0
+        tag: boost-1.87.0
 
   - name: libdwarf
     buildsystem: autotools

--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -340,5 +340,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        commit: 4f510d4268047175eee71692404011f0df20f056
+        commit: 21edc3a8c08602006a3d57f486444588f9326833
 


### PR DESCRIPTION
This pull request updates the `io.github.pemsley.coot.yaml` file to use different versions of dependencies. Specifically, it modifies the `boost` library tag and the `coot` repository commit hash.

Dependency version updates:

* [`io.github.pemsley.coot.yaml`](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL149-R149): Changed the `boost` library tag from `boost-1.88.0` to `boost-1.87.0`.
* [`io.github.pemsley.coot.yaml`](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL343-R343): Updated the `coot` repository commit hash from `4f510d4268047175eee71692404011f0df20f056` to `21edc3a8c08602006a3d57f486444588f9326833`.