### PR TITLE
Update libccp4 to version 8.0.0 for Beta channel

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -35,7 +35,7 @@ modules:
       - type: git
         url: https://github.com/project-gemmi/gemmi.git
         tag: v0.7.1
-  
+
   - name: fftw2
     buildsystem: autotools
     config-opts:
@@ -146,7 +146,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/boostorg/boost.git
-        tag: boost-1.88.0
+        tag: boost-1.87.0
 
   - name: libdwarf
     buildsystem: autotools

--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -340,5 +340,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        commit: 4f510d4268047175eee71692404011f0df20f056
+        commit: 21edc3a8c08602006a3d57f486444588f9326833
 


### PR DESCRIPTION
This pull request updates the `io.github.pemsley.coot.yaml` file to use a newer version of the `libccp4` dependency. The most important change is the update to the URL and checksum for the `libccp4` source archive.

Dependency update:

* Updated the `url` to point to `libccp4-8.0.0.tar.gz` and updated the corresponding `sha256` checksum to match the new version. This replaces the previous version `libccp4-6.5.1.tar.gz`. (`[io.github.pemsley.coot.yamlL74-R75](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL74-R75)`)