### PR TITLE
Merge pull request #75 from eunos-1128/master

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -31,6 +31,8 @@ modules:
     config-opts:
       - -DUSE_PYTHON=1
       - -DPYTHON_INSTALL_DIR=/app/lib/python3.12/site-packages
+    build-options:
+      cxxflags: "-fPIC -O2"
     sources:
       - type: git
         url: https://github.com/project-gemmi/gemmi.git
@@ -42,6 +44,8 @@ modules:
       - --enable-shared
       - --enable-float
       - --disable-static
+    build-options:
+      cflags: "-fPIC -O3"
     sources:
       - type: archive
         url: https://fftw.org/fftw-2.1.5.tar.gz
@@ -57,7 +61,7 @@ modules:
       - --enable-shared
       - --disable-static
     build-options:
-      cxxflags: "-g -O2"
+      cxxflags: "-g -O2 -fPIC -std=c++11"
     sources:
       - type: archive
         url: https://www2.mrc-lmb.cam.ac.uk/personal/pemsley/coot/dependencies/mmdb2-2.0.22.tar.gz
@@ -69,6 +73,9 @@ modules:
       - --enable-shared
       - --disable-static
       - --disable-fortran
+    build-options:
+      cflags: "-fPIC -O2"
+      cxxflags: "-fPIC -O2"
     sources:
       - type: archive
         url: https://www2.mrc-lmb.cam.ac.uk/personal/pemsley/coot/dependencies/libccp4-8.0.0.tar.gz
@@ -85,7 +92,7 @@ modules:
       - --enable-shared
       - --disable-static
     build-options:
-      cxxflags: "-g -O2 -fno-strict-aliasing -Wno-narrowing"
+      cxxflags: "-g -O2 -fno-strict-aliasing -Wno-narrowing -fPIC -std=c++11"
     sources:
       - type: archive
         url: https://www2.mrc-lmb.cam.ac.uk/personal/pemsley/coot/dependencies/clipper-2.1.20180802.tar.gz
@@ -111,7 +118,7 @@ modules:
   - name: raster3d
     buildsystem: simple
     build-options:
-      cxxflags: "-g -O2 -fno-strict-aliasing -Wno-narrowing"
+      cxxflags: "-g -O2 -fno-strict-aliasing -Wno-narrowing -fPIC"
     build-commands:
       - make linux
       - make all
@@ -181,12 +188,13 @@ modules:
     buildsystem: cmake-ninja
     builddir: true
     config-opts:
-      - -DDYNAMIC_ARCH=1
-      - -DUSE_OPENMP=1
-      - -DNUM_THREADS=56
-      - -DNO_SVE=1
+      - -DUSE_OPENMP=ON
+      - -DNUM_THREADS=64
+      - -DNO_SVE=ON
       - -DBUILD_SHARED_LIBS=ON
       - -DDYNAMIC_ARCH=ON
+    build-options:
+      cflags: "-fPIC -O3"
     post-install:
       - ln -s /app/lib/libopenblas.so /app/lib/libblas.so
       - ln -s /app/lib/libopenblas.so /app/lib/liblapack.so
@@ -201,6 +209,8 @@ modules:
       - --disable-debug
       - --disable-docs
       - --disable-dependency-tracking
+    build-options:
+      cflags: "-fPIC -O2"
     sources:
       - type: git
         url: https://github.com/ivmai/bdwgc
@@ -329,7 +339,7 @@ modules:
       - --with-backward
       - --with-libdw
     build-options:
-      cxxflags: "-g -O1"
+      cxxflags: "-g -O1 -fPIC"
       env:
         GLM_CFLAGS: "-I/app/include"
         GLM_LIBS: "-L/app/lib -lglm"


### PR DESCRIPTION
This pull request updates the `io.github.pemsley.coot.yaml` file to standardize and improve build configurations across multiple modules. The changes primarily involve adding or modifying compiler flags (`cflags` and `cxxflags`) to ensure compatibility and optimization, as well as updating some configuration options for specific modules.

### Compiler flag improvements:

* Added `-fPIC` to `cflags` and/or `cxxflags` for modules such as `gemmi`, `fftw`, `mmdb2`, `libccp4`, `clipper`, `raster3d`, and others to improve position-independent code generation. (`[[1]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efR34-R35)`, `[[2]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efR47-R48)`, `[[3]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL60-R64)`, `[[4]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efR76-R78)`, `[[5]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL88-R95)`, `[[6]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL114-R121)`, `[[7]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL332-R342)`)
* Updated `cxxflags` to include `-std=c++11` for modules like `mmdb2` and `clipper` to ensure compatibility with modern C++ standards. (`[[1]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL60-R64)`, `[[2]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL88-R95)`)

### Configuration updates:

* Adjusted `config-opts` for the `cmake-ninja` build system in the `openblas` module, including enabling `-DDYNAMIC_ARCH=ON`, updating `-DNUM_THREADS` to 64, and setting `-DUSE_OPENMP=ON` for better performance and multi-threading support. (`[io.github.pemsley.coot.yamlL184-R197](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL184-R197)`)