### PR TITLE
Bump to Release-1.1.17

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -353,5 +353,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        tag: Release-1.1.16
+        tag: Release-1.1.17
 


### PR DESCRIPTION
This pull request updates the version of the `coot` module in the `io.github.pemsley.coot.yaml` file to the latest release.

* [`io.github.pemsley.coot.yaml`](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL356-R356): Updated the `coot` module's Git tag from `Release-1.1.16` to `Release-1.1.17` to use the latest version.