### PR TITLE
Update coot module tag to Release-1.1.17-v2

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -353,5 +353,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        tag: Release-1.1.17
-
+        tag: Release-1.1.17-v2


### PR DESCRIPTION
This pull request updates the version tag for the `coot` module in the `io.github.pemsley.coot.yaml` file to reflect a new release.

* [`io.github.pemsley.coot.yaml`](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL356-R356): Updated the `tag` field for the `coot` module from `Release-1.1.17` to `Release-1.1.17-v2` to align with the latest version.