### PR TITLE
Update PyPI dependencies

### DIFF
--- a/deps/pypi-dependencies.json
+++ b/deps/pypi-dependencies.json
@@ -21,18 +21,18 @@
             "name": "python3-meson-python",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"meson-python\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"meson-python<0.16.0,>=0.15.0\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/7d/ec/40c0ddd29ef4daa6689a2b9c5ced47d5b58fa54ae149b19e9a97f4979c8c/meson_python-0.17.1-py3-none-any.whl",
-                    "sha256": "30a75c52578ef14aff8392677b09c39346e0a24d2b2c6204b8ed30583c11269c"
+                    "url": "https://files.pythonhosted.org/packages/1f/60/b10b11ab470a690d5777310d6cfd1c9bdbbb0a1313a78c34a1e82e0b9d27/meson_python-0.15.0-py3-none-any.whl",
+                    "sha256": "3ae38253ff02b2e947a05e362a2eaf5a9a09d133c5666b4123399ee5fbf2e591"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl",
-                    "sha256": "09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"
+                    "url": "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl",
+                    "sha256": "29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"
                 },
                 {
                     "type": "file",
@@ -50,8 +50,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/8e/9e/dadc3831f40e22c1b3925f07894646ada7906ef5b48db5c5eb2b03ca9faa/nanobind-2.5.0-py3-none-any.whl",
-                    "sha256": "e1e5c816e5d10f0b252d82ba7f769f0f6679f5e043cf406aec3d9e184bf2a60d"
+                    "url": "https://files.pythonhosted.org/packages/96/14/989883082b395146120d34ca7e484a2b24cb73b0e428576a3a4249bd4082/nanobind-2.7.0-py3-none-any.whl",
+                    "sha256": "73b12d0e751d140d6c1bf4b215e18818a8debfdb374f08dc3776ad208d808e74"
                 }
             ]
         },

--- a/deps/pypi-dependencies.json
+++ b/deps/pypi-dependencies.json
@@ -21,7 +21,7 @@
             "name": "python3-meson-python",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"meson-python<0.16.0,>=0.15.0\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"meson-python>=0.15.0,<0.16.0\" --no-build-isolation"
             ],
             "sources": [
                 {
@@ -59,7 +59,7 @@
             "name": "python3-numpy",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"numpy==1.26.4\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"numpy==1.26.4\" --ignore-installed --no-build-isolation"
             ],
             "sources": [
                 {

--- a/deps/pypi-dependencies.json
+++ b/deps/pypi-dependencies.json
@@ -56,17 +56,26 @@
             ]
         },
         {
-            "name": "python3-numpy",
+            "name": "python3-Cython",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"numpy==1.26.4\" --ignore-installed --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"cython==3.0.12\" --ignore-installed --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/5a/25/886e197c97a4b8e254173002cdc141441e878ff29aaa7d9ba560cd6e4866/cython-3.0.12.tar.gz",
                     "sha256": "b988bb297ce76c671e28c97d017b95411010f7c77fa6623dd0bb47eed1aee1bc"
-                },
+                }
+            ]
+        },
+        {
+            "name": "python3-numpy",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"numpy==1.26.4\" --ignore-installed --no-build-isolation"
+            ],
+            "sources": [
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz",

--- a/deps/pypi-dependencies.json
+++ b/deps/pypi-dependencies.json
@@ -64,6 +64,11 @@
             "sources": [
                 {
                     "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/5a/25/886e197c97a4b8e254173002cdc141441e878ff29aaa7d9ba560cd6e4866/cython-3.0.12.tar.gz",
+                    "sha256": "b988bb297ce76c671e28c97d017b95411010f7c77fa6623dd0bb47eed1aee1bc"
+                },
+                {
+                    "type": "file",
                     "url": "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz",
                     "sha256": "2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010"
                 }

--- a/deps/pypi-dependencies.sh
+++ b/deps/pypi-dependencies.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-./flatpak-builder-tools/pip/flatpak-pip-generator --runtime='org.gnome.Sdk//48' --requirements-file='requirements.txt' --output pypi-dependencies
+# Cython version corresponding to the specified numpy version must be manually added to pypi-dependencies.json afterwards
+./flatpak-builder-tools/pip/flatpak-pip-generator --runtime='org.gnome.Sdk//48' --requirements-file='requirements.txt' --output=pypi-dependencies --ignore-installed=numpy

--- a/deps/requirements.txt
+++ b/deps/requirements.txt
@@ -1,6 +1,4 @@
-mako
-markdown
 markupsafe
-meson-python
+meson-python>=0.15.0,<0.16.0
 nanobind
 numpy==1.26.4

--- a/deps/requirements.txt
+++ b/deps/requirements.txt
@@ -1,3 +1,4 @@
+Cython>=0.29.34,<3.1
 markupsafe
 meson-python>=0.15.0,<0.16.0
 nanobind

--- a/deps/requirements.txt
+++ b/deps/requirements.txt
@@ -1,4 +1,3 @@
-Cython>=0.29.34,<3.1
 markupsafe
 meson-python>=0.15.0,<0.16.0
 nanobind

--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -24,6 +24,26 @@ cleanup:
   - "*.a"
 
 modules:
+  - name: openblas
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DUSE_OPENMP=ON
+      - -DNUM_THREADS=64
+      - -DNO_SVE=ON
+      - -DBUILD_SHARED_LIBS=ON
+      - -DDYNAMIC_ARCH=ON
+    build-options:
+      cflags: "-fPIC -O3"
+    post-install:
+      - ln -s /app/lib/libopenblas.so /app/lib/libblas.so
+      - ln -s /app/lib/libopenblas.so /app/lib/liblapack.so
+    sources:
+      - type: archive
+        url: https://github.com/OpenMathLib/OpenBLAS/archive/refs/tags/v0.3.28.tar.gz
+        sha256: f1003466ad074e9b0c8d421a204121100b0751c96fc6fcf3d1456bd12f8a00a1
+
+  # markupsafe, meson-python, nanobind, numpy
   - deps/pypi-dependencies.json
 
   - name: gemmi
@@ -183,25 +203,6 @@ modules:
       - type: archive
         url: https://github.com/g-truc/glm/archive/refs/tags/1.0.1.tar.gz
         sha256: 9f3174561fd26904b23f0db5e560971cbf9b3cbda0b280f04d5c379d03bf234c
-
-  - name: openblas
-    buildsystem: cmake-ninja
-    builddir: true
-    config-opts:
-      - -DUSE_OPENMP=ON
-      - -DNUM_THREADS=64
-      - -DNO_SVE=ON
-      - -DBUILD_SHARED_LIBS=ON
-      - -DDYNAMIC_ARCH=ON
-    build-options:
-      cflags: "-fPIC -O3"
-    post-install:
-      - ln -s /app/lib/libopenblas.so /app/lib/libblas.so
-      - ln -s /app/lib/libopenblas.so /app/lib/liblapack.so
-    sources:
-      - type: archive
-        url: https://github.com/OpenMathLib/OpenBLAS/archive/refs/tags/v0.3.28.tar.gz
-        sha256: f1003466ad074e9b0c8d421a204121100b0751c96fc6fcf3d1456bd12f8a00a1
 
   - name: bdw-gc
     buildsystem: autotools

--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -39,9 +39,9 @@ modules:
       - ln -s /app/lib/libopenblas.so /app/lib/libblas.so
       - ln -s /app/lib/libopenblas.so /app/lib/liblapack.so
     sources:
-      - type: archive
-        url: https://github.com/OpenMathLib/OpenBLAS/archive/refs/tags/v0.3.28.tar.gz
-        sha256: f1003466ad074e9b0c8d421a204121100b0751c96fc6fcf3d1456bd12f8a00a1
+      - type: git
+        url: https://github.com/OpenMathLib/OpenBLAS.git
+        tag: v0.3.28
 
   # markupsafe, meson-python, nanobind, numpy
   - deps/pypi-dependencies.json


### PR DESCRIPTION
This pull request updates dependencies and build configurations for Python packages and external libraries. Key changes include version updates for several Python dependencies, the addition of `Cython` to the dependency list, and adjustments to the OpenBLAS module configuration. 

### Dependency Updates:
* Updated `meson-python` to version `>=0.15.0,<0.16.0` and replaced its source URL and checksum in `deps/pypi-dependencies.json`.
* Updated `packaging` to version `25.0` and `nanobind` to version `2.7.0` with corresponding source URL and checksum changes in `deps/pypi-dependencies.json`. [[1]](diffhunk://#diff-b396deff21a365acd9245f182c176c42d53044b13a845d06c708f0aa6ac526a2L24-R35) [[2]](diffhunk://#diff-b396deff21a365acd9245f182c176c42d53044b13a845d06c708f0aa6ac526a2L53-R76)
* Added `Cython` version `3.0.12` as a new dependency in `deps/pypi-dependencies.json`.
* Updated `requirements.txt` to reflect changes to `meson-python` and removed unused dependencies like `mako` and `markdown`.

### Build Configuration Changes:
* Modified `deps/pypi-dependencies.sh` to include a note about manually adding `Cython` and added the `--ignore-installed=numpy` flag to the generator command.

### OpenBLAS Module Adjustments:
* Re-added the OpenBLAS module configuration in `io.github.pemsley.coot.yaml` with updated build options and source type set to `git` instead of `archive`.
* Removed a duplicate OpenBLAS module configuration from the `modules` section in the same file.