### PR TITLE
Bump to `a374e03`

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -354,5 +354,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        commit: a1e8ef5b22fcd6348807923943bd984494e594bf
+        commit: a374e0364bbe7b9eb06b5c8302db38d24ae02007
         


### PR DESCRIPTION
This pull request updates the commit reference in the `io.github.pemsley.coot.yaml` file to point to a newer version of the `coot` repository.