### PR TITLE
Bump to Release-1.1.18

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -7,9 +7,7 @@ finish-args:
   - --socket=x11
   - --share=ipc
   - --device=dri
-  - --filesystem=host
-  - --filesystem=xdg-cache
-  - --filesystem=xdg-data
+  - --filesystem=home
   - --share=network
   - --env=GDK_CORE_DEVICE_EVENTS=1
   - --env=COOT_PREFIX=/app

--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -356,5 +356,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        commit: a1e8ef5b22fcd6348807923943bd984494e594bf
+        tag: Release-1.1.18
         

--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -7,7 +7,9 @@ finish-args:
   - --socket=x11
   - --share=ipc
   - --device=dri
-  - --filesystem=home
+  - --filesystem=host
+  - --filesystem=xdg-cache
+  - --filesystem=xdg-data
   - --share=network
   - --env=GDK_CORE_DEVICE_EVENTS=1
   - --env=COOT_PREFIX=/app

--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -51,14 +51,14 @@ modules:
   - name: gemmi
     buildsystem: cmake-ninja
     config-opts:
-      - -DUSE_PYTHON=1
+      - -DUSE_PYTHON=ON
       - -DPYTHON_INSTALL_DIR=/app/lib/python3.12/site-packages
     build-options:
       cxxflags: "-fPIC -O2"
     sources:
       - type: git
         url: https://github.com/project-gemmi/gemmi.git
-        tag: v0.7.1
+        tag: v0.7.3
 
   - name: fftw2
     buildsystem: autotools


### PR DESCRIPTION
This pull request updates the `io.github.pemsley.coot.yaml` configuration file to ensure compatibility with newer versions of dependencies and improve clarity in the build process. The most important changes involve updates to dependency versions and adjustments to source references.

### Dependency Updates:
* Updated the `gemmi` module configuration to use `-DUSE_PYTHON=ON` instead of `-DUSE_PYTHON=1` for clarity and consistency with modern conventions. The version tag for `gemmi` was also updated from `v0.7.1` to `v0.7.3`. (`[io.github.pemsley.coot.yamlL52-R59](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL52-R59)`)

### Source Reference Updates:
* Changed the `coot` module source reference from a specific commit (`a1e8ef5b22fcd6348807923943bd984494e594bf`) to a release tag (`Release-1.1.18`) for easier tracking of the version being built. (`[io.github.pemsley.coot.yamlL357-R357](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL357-R357)`)