### PR TITLE
 Bump to Release-1.1.18

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -49,14 +49,14 @@ modules:
   - name: gemmi
     buildsystem: cmake-ninja
     config-opts:
-      - -DUSE_PYTHON=1
+      - -DUSE_PYTHON=ON
       - -DPYTHON_INSTALL_DIR=/app/lib/python3.12/site-packages
     build-options:
       cxxflags: "-fPIC -O2"
     sources:
       - type: git
         url: https://github.com/project-gemmi/gemmi.git
-        tag: v0.7.1
+        tag: v0.7.3
 
   - name: fftw2
     buildsystem: autotools
@@ -354,5 +354,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        commit: a374e0364bbe7b9eb06b5c8302db38d24ae02007
+        tag: Release-1.1.18
         


### PR DESCRIPTION
This pull request updates the `io.github.pemsley.coot.yaml` file to improve module configurations and dependencies. The most important changes involve updating build options and source references for better compatibility and stability.

### Module Configuration Updates:
* Updated the `gemmi` module's `config-opts` to use `-DUSE_PYTHON=ON` instead of `-DUSE_PYTHON=1` for consistency with CMake conventions.
* Changed the `gemmi` module's source tag from `v0.7.1` to `v0.7.3` to use the latest available version.

### Dependency Updates:
* Updated the `coot` module's source reference from a specific commit (`a374e0364bbe7b9eb06b5c8302db38d24ae02007`) to a tagged release (`Release-1.1.18`) for better versioning and clarity.