### PR TITLE
 Bump to Release-1.1.18

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -49,14 +49,14 @@ modules:
   - name: gemmi
     buildsystem: cmake-ninja
     config-opts:
-      - -DUSE_PYTHON=1
+      - -DUSE_PYTHON=ON
       - -DPYTHON_INSTALL_DIR=/app/lib/python3.12/site-packages
     build-options:
       cxxflags: "-fPIC -O2"
     sources:
       - type: git
         url: https://github.com/project-gemmi/gemmi.git
-        tag: v0.7.1
+        tag: v0.7.3
 
   - name: fftw2
     buildsystem: autotools
@@ -354,5 +354,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        commit: a374e0364bbe7b9eb06b5c8302db38d24ae02007
+        tag: Release-1.1.18
         


### PR DESCRIPTION
This pull request updates the `io.github.pemsley.coot.yaml` file to improve module configuration and align with newer versions of dependencies. The most important changes include updating build options for the `gemmi` module and switching to tagged releases for both `gemmi` and `coot` modules.

### Updates to module configuration:

* [`io.github.pemsley.coot.yaml`](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL52-R59): Changed `USE_PYTHON` build option for the `gemmi` module from `1` to `ON` for better clarity and compatibility.

### Updates to dependency versions:

* [`io.github.pemsley.coot.yaml`](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL52-R59): Updated the `gemmi` module to use tag `v0.7.3` instead of `v0.7.1`.
* [`io.github.pemsley.coot.yaml`](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL357-R357): Updated the `coot` module to use tag `Release-1.1.18` instead of a specific commit hash.