### PR TITLE
Bump to `6629ed9`

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -49,14 +49,14 @@ modules:
   - name: gemmi
     buildsystem: cmake-ninja
     config-opts:
-      - -DUSE_PYTHON=1
+      - -DUSE_PYTHON=ON
       - -DPYTHON_INSTALL_DIR=/app/lib/python3.12/site-packages
     build-options:
       cxxflags: "-fPIC -O2"
     sources:
       - type: git
         url: https://github.com/project-gemmi/gemmi.git
-        tag: v0.7.1
+        tag: v0.7.3
 
   - name: fftw2
     buildsystem: autotools
@@ -354,5 +354,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        commit: a374e0364bbe7b9eb06b5c8302db38d24ae02007
+        tag: Release-1.1.18
         

--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -354,5 +354,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        tag: Release-1.1.18
+        commit: 6629ed951735a500eda5df8744cb20179a5a7b30
         


### PR DESCRIPTION
This pull request updates the source reference for the `coot` module to use a specific commit instead of a tagged release. This ensures that the build uses an exact code state.

- Dependency management:
  * Updated the `coot` module in `io.github.pemsley.coot.yaml` to reference commit `6629ed951735a500eda5df8744cb20179a5a7b30` instead of the `Release-1.1.18` tag.