### PR TITLE
Add `x-checker-data` to the `coot` module 

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -366,3 +366,7 @@ modules:
       - type: git
         url: https://github.com/pemsley/coot.git
         tag: Release-1.1.19
+        x-checker-data: 
+          type: github-releases
+          project: pemsley/coot
+          version-pattern: ^Release-([\d.]+)$


### PR DESCRIPTION
This pull request makes a small update to the module metadata for `coot` by adding automated version checking using GitHub releases.

- Added `x-checker-data` to the `coot` module in `io.github.pemsley.coot.yaml` to enable automatic version checks based on GitHub releases.