### PR TITLE
Fix x-checker-data for coot module

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -363,10 +363,10 @@ modules:
       - desktop-file-edit --set-key=Icon --set-value=${FLATPAK_ID} ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
       - install -Dm644 coot.appdata.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
     sources:
-      - type: archive
-        url: https://github.com/pemsley/coot/archive/Release-1.1.19.tar.gz
-        sha256: 514b21e59ef1f4c69f1361309c5c7252940f0babf5aeacf1f0382f86cc82313a
+      - type: git
+        url: https://github.com/pemsley/coot.git
+        tag: Release-1.1.19
+        commit: de1f0ffea43d2df89e16a6395ae8e6a222f61d8d
         x-checker-data:
-          type: github-releases
-          project: pemsley/coot
-          version-pattern: ^Release-([\d.]+)$
+          type: git
+          tag-pattern: '^Release-([0-9]+(?:\.[0-9]+)*)$'


### PR DESCRIPTION
This pull request updates the configuration for the `coot` module to improve version tracking and reproducibility. The most important changes are:

Module source and versioning improvements:

* Switched the `x-checker-data` type from `github-releases` to `git` and updated the tag pattern to a more precise regular expression for release tags.
* Added a specific `commit` hash (`de1f0ffea43d2df89e16a6395ae8e6a222f61d8d`) to ensure the build uses an exact version of the source code.