### PR TITLE
Bump coot to `642a2cd`

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -1,6 +1,6 @@
 app-id: io.github.pemsley.coot
 runtime: org.gnome.Platform
-runtime-version: "48"  # include python 3.12.9
+runtime-version: '48'  # include python 3.12.9
 sdk: org.gnome.Sdk
 command: coot
 finish-args:
@@ -20,8 +20,8 @@ cleanup:
   - /share/doc
   - /share/info
   - /share/man
-  - "*.la"
-  - "*.a"
+  - '*.la'
+  - '*.a'
 
 modules:
   - name: openblas
@@ -34,7 +34,7 @@ modules:
       - -DBUILD_SHARED_LIBS=ON
       - -DDYNAMIC_ARCH=ON
     build-options:
-      cflags: "-fPIC -O3"
+      cflags: -fPIC -O3
     post-install:
       - ln -s /app/lib/libopenblas.so /app/lib/libblas.so
       - ln -s /app/lib/libopenblas.so /app/lib/liblapack.so
@@ -64,7 +64,7 @@ modules:
       - -DUSE_PYTHON=ON
       - -DPYTHON_INSTALL_DIR=/app/lib/python3.12/site-packages
     build-options:
-      cxxflags: "-fPIC -O2"
+      cxxflags: -fPIC -O2
     sources:
       - type: git
         url: https://github.com/project-gemmi/gemmi.git
@@ -77,7 +77,7 @@ modules:
       - --enable-float
       - --disable-static
     build-options:
-      cflags: "-fPIC -O3"
+      cflags: -fPIC -O3
     sources:
       - type: archive
         url: https://fftw.org/fftw-2.1.5.tar.gz
@@ -93,7 +93,7 @@ modules:
       - --enable-shared
       - --disable-static
     build-options:
-      cxxflags: "-g -O2 -fPIC -std=c++11"
+      cxxflags: -g -O2 -fPIC -std=c++11
     sources:
       - type: archive
         url: https://www2.mrc-lmb.cam.ac.uk/personal/pemsley/coot/dependencies/mmdb2-2.0.22.tar.gz
@@ -106,8 +106,8 @@ modules:
       - --disable-static
       - --disable-fortran
     build-options:
-      cflags: "-fPIC -O2"
-      cxxflags: "-fPIC -O2"
+      cflags: -fPIC -O2
+      cxxflags: -fPIC -O2
     sources:
       - type: archive
         url: https://www2.mrc-lmb.cam.ac.uk/personal/pemsley/coot/dependencies/libccp4-8.0.0.tar.gz
@@ -124,7 +124,7 @@ modules:
       - --enable-shared
       - --disable-static
     build-options:
-      cxxflags: "-g -O2 -fno-strict-aliasing -Wno-narrowing -fPIC -std=c++11"
+      cxxflags: -g -O2 -fno-strict-aliasing -Wno-narrowing -fPIC -std=c++11
     sources:
       - type: archive
         url: https://www2.mrc-lmb.cam.ac.uk/personal/pemsley/coot/dependencies/clipper-2.1.20180802.tar.gz
@@ -150,7 +150,7 @@ modules:
   - name: raster3d
     buildsystem: simple
     build-options:
-      cxxflags: "-g -O2 -fno-strict-aliasing -Wno-narrowing -fPIC"
+      cxxflags: -g -O2 -fno-strict-aliasing -Wno-narrowing -fPIC
     build-commands:
       - make linux
       - make all
@@ -178,11 +178,14 @@ modules:
   - name: boost
     buildsystem: simple
     build-commands:
-      - ./bootstrap.sh --without-icu --with-python=python3.12 --with-python-root=/usr --with-libraries=system,python,regex,thread,serialization,iostreams,program_options --prefix=/app --libdir=/app/lib
-      - ./b2 install --prefix=/app --libdir=/app/lib linkflags=-L/usr/lib python=3.12 -d2 -j$FLATPAK_BUILDER_N_JOBS threading=multi link=shared,static
+      - ./bootstrap.sh --without-icu --with-python=python3.12 --with-python-root=/usr
+        --with-libraries=system,python,regex,thread,serialization,iostreams,program_options
+        --prefix=/app --libdir=/app/lib
+      - ./b2 install --prefix=/app --libdir=/app/lib linkflags=-L/usr/lib python=3.12
+        -d2 -j$FLATPAK_BUILDER_N_JOBS threading=multi link=shared,static
     build-options:
-      cflags: "-fPIC"
-      cxxflags: "-fPIC -std=c++14"
+      cflags: -fPIC
+      cxxflags: -fPIC -std=c++14
     cleanup:
       - /share/boost
     sources:
@@ -209,8 +212,8 @@ modules:
   - name: glm
     buildsystem: cmake
     config-opts:
-     - -DGLM_BUILD_TESTS=OFF
-     - -DBUILD_SHARED_LIBS=ON
+      - -DGLM_BUILD_TESTS=OFF
+      - -DBUILD_SHARED_LIBS=ON
     sources:
       - type: archive
         url: https://github.com/g-truc/glm/archive/refs/tags/1.0.1.tar.gz
@@ -223,7 +226,7 @@ modules:
       - --disable-docs
       - --disable-dependency-tracking
     build-options:
-      cflags: "-fPIC -O2"
+      cflags: -fPIC -O2
     sources:
       - type: git
         url: https://github.com/ivmai/bdwgc
@@ -282,7 +285,7 @@ modules:
     buildsystem: cmake-ninja
     builddir: true
     config-opts:
-      - "-DCMAKE_CXX_STANDARD=17"
+      - -DCMAKE_CXX_STANDARD=17
     sources:
       - type: archive
         url: https://github.com/catchorg/Catch2/archive/refs/tags/v3.7.1.tar.gz
@@ -352,10 +355,10 @@ modules:
       - --with-backward
       - --with-libdw
     build-options:
-      cxxflags: "-g -O1 -fPIC"
+      cxxflags: -g -O1 -fPIC
       env:
-        GLM_CFLAGS: "-I/app/include"
-        GLM_LIBS: "-L/app/lib -lglm"
+        GLM_CFLAGS: -I/app/include
+        GLM_LIBS: -L/app/lib -lglm
     post-install:
       - cp -r python/ ${FLATPAK_DEST}/share/coot/
       - install -Dm644 pixmaps/icons/coot.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
@@ -365,4 +368,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/pemsley/coot.git
-        commit: 2ba9dfaf790e15cabe23011433d8f9ba3fb9e032
+        commit: 642a2cdc3ba8daf3ffbab519a0d6a2d57b82c2c0


### PR DESCRIPTION
This pull request makes a series of small but important formatting and consistency improvements to the `io.github.pemsley.coot.yaml` Flatpak manifest. The main focus is on standardizing the use of quotes, improving YAML style, and enhancing readability, especially in build options and command lists.

Key improvements include:

**YAML formatting and quoting consistency:**

* Changed double quotes to single quotes for string values and glob patterns throughout the manifest for consistency [[1]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL3-R3) [[2]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL23-R24).
* Removed unnecessary quotes from `cflags`, `cxxflags`, and environment variable values, aligning with YAML best practices [[1]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL37-R37) [[2]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL67-R67) [[3]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL80-R80) [[4]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL96-R96) [[5]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL109-R110) [[6]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL127-R127) [[7]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL153-R153) [[8]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL181-R188) [[9]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL226-R229) [[10]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL285-R288) [[11]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL355-R361).

**Readability and maintainability:**

* Reformatted long command lines in the boost module to use YAML's multi-line syntax for improved readability.

**Dependency updates:**

* Updated the `coot` source commit to a newer revision, ensuring the build uses the latest code.