### PR TITLE
Add the `--socket=pulseaudio` to enable audio support

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -5,6 +5,7 @@ sdk: org.gnome.Sdk
 command: coot
 finish-args:
   - --socket=x11
+  - --socket=pulseaudio
   - --share=ipc
   - --device=dri
   - --filesystem=home


### PR DESCRIPTION
This pull request makes a minor update to the Flatpak manifest by adding support for PulseAudio. This allows the application to access audio features when running in a sandboxed environment.

* Flatpak manifest (`io.github.pemsley.coot.yaml`): Added the `--socket=pulseaudio` permission to enable audio support.