### PR TITLE
Change source type to `archive` for flatpak-external-data-checker

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -299,6 +299,8 @@ modules:
           stable-only: true
           url-template: https://github.com/ivmai/bdwgc/archive/refs/tags/v$version.tar.gz
 
+  # NOTE: Guile 3.0 is currently incompatible with the GTK4-based Coot build.
+  # Keep at 2.2.7 until upstream supports 3.0.
   - name: guile
     buildsystem: autotools
     config-opts:


### PR DESCRIPTION
This pull request updates the `io.github.pemsley.coot.yaml` file to improve reproducibility and reliability of dependency sources by switching from git checkouts to versioned release archives for many dependencies. Additionally, it introduces SHA256 checksums for source verification and updates metadata for automated version checking. There are also minor improvements to the RDKit integration.

**Dependency source improvements:**

* Changed the source type for several dependencies (e.g., OpenBLAS, Gemmi, libgd, Boost, glm, bdw-gc, swig, Catch2, eigen) from `git` repositories to versioned release archives, and added corresponding `sha256` checksums for integrity verification. [[1]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL51-R60) [[2]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL70-R79) [[3]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL155-R165) [[4]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL207-R218) [[5]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL245-R259) [[6]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL262-R277) [[7]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL315-R331) [[8]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL329-R346) [[9]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL343-R361)
* Updated `x-checker-data` for these dependencies to include `stable-only` flags and improved `url-template` patterns for automated version checking. [[1]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL51-R60) [[2]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL70-R79) [[3]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL155-R165) [[4]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL207-R218) [[5]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efR232) [[6]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efR244) [[7]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL245-R259) [[8]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL262-R277) [[9]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL315-R331) [[10]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL329-R346) [[11]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL343-R361)

**RDKit integration improvements:**

* Added a clarifying comment to the `enum.h` source entry and improved the shell script to explicitly place `enum.h` in the required location, with a comment to clarify intent. [[1]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL390-R403) [[2]](diffhunk://#diff-55b9e84a877dbbef6cbca71f44f2c253217232100c0d81f840e1abf5346b24efL403-R417)
* Updated a shell command comment to clarify that it prevents downloading `better_enums` during RDKit build.