### PR TITLE
chore: add auto-merge workflow, drop alpha branch, relicense to 0BSD

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,63 @@
+name: Auto-merge bot bump PRs
+
+on:
+  status: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge:
+    if: |
+      github.event.state == 'success' &&
+      startsWith(github.event.context, 'builds/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find matching open PR
+        id: find-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_SHA: ${{ github.event.sha }}
+        run: |
+          PR_NUMBER=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --head "bot/upstream-coot-beta" \
+            --base "beta" \
+            --state open \
+            --json number,headRefOid \
+            --jq --arg sha "$COMMIT_SHA" \
+            '.[] | select(.headRefOid == $sha) | .number')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No matching PR, skipping."
+            exit 0
+          fi
+          echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      - name: Check all statuses on PR are successful
+        if: steps.find-pr.outputs.number != ''
+        id: checks
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ROLLUP=$(gh pr view "${{ steps.find-pr.outputs.number }}" \
+            --repo "${{ github.repository }}" \
+            --json statusCheckRollup \
+            --jq '.statusCheckRollup')
+          NOT_OK=$(echo "$ROLLUP" | \
+            jq '[.[] | select(.conclusion != "SUCCESS" and .state != "SUCCESS")] | length')
+          if [ "$NOT_OK" -gt 0 ]; then
+            echo "Checks not all passing yet, skipping."
+            exit 0
+          fi
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
+      - name: Merge PR
+        if: steps.checks.outputs.ready == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge "${{ steps.find-pr.outputs.number }}" \
+            --repo "${{ github.repository }}" \
+            --squash \
+            --delete-branch

--- a/.github/workflows/upstream-coot-bump.yml
+++ b/.github/workflows/upstream-coot-bump.yml
@@ -2,7 +2,6 @@ name: Bump upstream coot commit
 
 on:
   schedule:
-    # Every 1 hour, at :17 to avoid the on-the-hour Actions congestion.
     - cron: '17 */1 * * *'
   workflow_dispatch: {}
 
@@ -15,16 +14,11 @@ jobs:
     if: github.repository_owner == 'flathub'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [beta, alpha]
     steps:
-      - name: Checkout ${{ matrix.target }}
-        # actions/checkout v4.2.2
+      - name: Checkout beta
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          ref: ${{ matrix.target }}
+          ref: beta
 
       - name: Read currently pinned ref for the coot module
         id: cur
@@ -104,17 +98,16 @@ jobs:
           open(path, "w").write(src2)
           PY
 
-      - name: Create Pull Request to ${{ matrix.target }}
+      - name: Create Pull Request to beta
         if: steps.check.outputs.changed == 'true'
         id: create-pr
-        # peter-evans/create-pull-request v7.0.8
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
         with:
-          base: ${{ matrix.target }}
-          branch: bot/upstream-coot-${{ matrix.target }}
+          base: beta
+          branch: bot/upstream-coot-beta
           commit-message: |
             coot: bump to ${{ steps.up.outputs.short }}
-          title: "coot: bump upstream to ${{ steps.up.outputs.short }} (${{ matrix.target }})"
+          title: "coot: bump upstream to ${{ steps.up.outputs.short }} (beta)"
           body: |
             Upstream https://github.com/pemsley/coot HEAD has new commits.
             This PR updates the `commit:` field of the `coot` module in
@@ -123,7 +116,7 @@ jobs:
             - old: `${{ steps.cur.outputs.sha }}`
             - new: `${{ steps.up.outputs.sha }}`
 
-            Auto-generated. Target branch: `${{ matrix.target }}`.
+            Auto-generated. Target branch: `beta`.
           labels: |
             automated
             upstream-bump
@@ -132,3 +125,10 @@ jobs:
           delete-branch: true
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+
+      - name: Enable auto-merge
+        if: steps.check.outputs.changed == 'true' && steps.create-pr.outputs.pull-request-operation != 'none'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ steps.create-pr.outputs.pull-request-url }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/upstream-coot-bump.yml
+++ b/.github/workflows/upstream-coot-bump.yml
@@ -126,9 +126,3 @@ jobs:
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
 
-      - name: Enable auto-merge
-        if: steps.check.outputs.changed == 'true' && steps.create-pr.outputs.pull-request-operation != 'none'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ steps.create-pr.outputs.pull-request-url }}
-        run: gh pr merge --auto --squash "$PR_URL"

--- a/LICENSE
+++ b/LICENSE
@@ -1,121 +1,14 @@
-Creative Commons Legal Code
+BSD Zero Clause License
 
-CC0 1.0 Universal
+Copyright (c) 2026 io.github.pemsley.coot contributors
 
-    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
-    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
-    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
-    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
-    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
-    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
-    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
-    HEREUNDER.
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
 
-Statement of Purpose
-
-The laws of most jurisdictions throughout the world automatically confer
-exclusive Copyright and Related Rights (defined below) upon the creator
-and subsequent owner(s) (each and all, an "owner") of an original work of
-authorship and/or a database (each, a "Work").
-
-Certain owners wish to permanently relinquish those rights to a Work for
-the purpose of contributing to a commons of creative, cultural and
-scientific works ("Commons") that the public can reliably and without fear
-of later claims of infringement build upon, modify, incorporate in other
-works, reuse and redistribute as freely as possible in any form whatsoever
-and for any purposes, including without limitation commercial purposes.
-These owners may contribute to the Commons to promote the ideal of a free
-culture and the further production of creative, cultural and scientific
-works, or to gain reputation or greater distribution for their Work in
-part through the use and efforts of others.
-
-For these and/or other purposes and motivations, and without any
-expectation of additional consideration or compensation, the person
-associating CC0 with a Work (the "Affirmer"), to the extent that he or she
-is an owner of Copyright and Related Rights in the Work, voluntarily
-elects to apply CC0 to the Work and publicly distribute the Work under its
-terms, with knowledge of his or her Copyright and Related Rights in the
-Work and the meaning and intended legal effect of CC0 on those rights.
-
-1. Copyright and Related Rights. A Work made available under CC0 may be
-protected by copyright and related or neighboring rights ("Copyright and
-Related Rights"). Copyright and Related Rights include, but are not
-limited to, the following:
-
-  i. the right to reproduce, adapt, distribute, perform, display,
-     communicate, and translate a Work;
- ii. moral rights retained by the original author(s) and/or performer(s);
-iii. publicity and privacy rights pertaining to a person's image or
-     likeness depicted in a Work;
- iv. rights protecting against unfair competition in regards to a Work,
-     subject to the limitations in paragraph 4(a), below;
-  v. rights protecting the extraction, dissemination, use and reuse of data
-     in a Work;
- vi. database rights (such as those arising under Directive 96/9/EC of the
-     European Parliament and of the Council of 11 March 1996 on the legal
-     protection of databases, and under any national implementation
-     thereof, including any amended or successor version of such
-     directive); and
-vii. other similar, equivalent or corresponding rights throughout the
-     world based on applicable law or treaty, and any national
-     implementations thereof.
-
-2. Waiver. To the greatest extent permitted by, but not in contravention
-of, applicable law, Affirmer hereby overtly, fully, permanently,
-irrevocably and unconditionally waives, abandons, and surrenders all of
-Affirmer's Copyright and Related Rights and associated claims and causes
-of action, whether now known or unknown (including existing as well as
-future claims and causes of action), in the Work (i) in all territories
-worldwide, (ii) for the maximum duration provided by applicable law or
-treaty (including future time extensions), (iii) in any current or future
-medium and for any number of copies, and (iv) for any purpose whatsoever,
-including without limitation commercial, advertising or promotional
-purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
-member of the public at large and to the detriment of Affirmer's heirs and
-successors, fully intending that such Waiver shall not be subject to
-revocation, rescission, cancellation, termination, or any other legal or
-equitable action to disrupt the quiet enjoyment of the Work by the public
-as contemplated by Affirmer's express Statement of Purpose.
-
-3. Public License Fallback. Should any part of the Waiver for any reason
-be judged legally invalid or ineffective under applicable law, then the
-Waiver shall be preserved to the maximum extent permitted taking into
-account Affirmer's express Statement of Purpose. In addition, to the
-extent the Waiver is so judged Affirmer hereby grants to each affected
-person a royalty-free, non transferable, non sublicensable, non exclusive,
-irrevocable and unconditional license to exercise Affirmer's Copyright and
-Related Rights in the Work (i) in all territories worldwide, (ii) for the
-maximum duration provided by applicable law or treaty (including future
-time extensions), (iii) in any current or future medium and for any number
-of copies, and (iv) for any purpose whatsoever, including without
-limitation commercial, advertising or promotional purposes (the
-"License"). The License shall be deemed effective as of the date CC0 was
-applied by Affirmer to the Work. Should any part of the License for any
-reason be judged legally invalid or ineffective under applicable law, such
-partial invalidity or ineffectiveness shall not invalidate the remainder
-of the License, and in such case Affirmer hereby affirms that he or she
-will not (i) exercise any of his or her remaining Copyright and Related
-Rights in the Work or (ii) assert any associated claims and causes of
-action with respect to the Work, in either case contrary to Affirmer's
-express Statement of Purpose.
-
-4. Limitations and Disclaimers.
-
- a. No trademark or patent rights held by Affirmer are waived, abandoned,
-    surrendered, licensed or otherwise affected by this document.
- b. Affirmer offers the Work as-is and makes no representations or
-    warranties of any kind concerning the Work, express, implied,
-    statutory or otherwise, including without limitation warranties of
-    title, merchantability, fitness for a particular purpose, non
-    infringement, or the absence of latent or other defects, accuracy, or
-    the present or absence of errors, whether or not discoverable, all to
-    the greatest extent permissible under applicable law.
- c. Affirmer disclaims responsibility for clearing rights of other persons
-    that may apply to the Work or any use thereof, including without
-    limitation any person's Copyright and Related Rights in the Work.
-    Further, Affirmer disclaims responsibility for obtaining any necessary
-    consents, permissions or other rights required for any use of the
-    Work.
- d. Affirmer understands and acknowledges that Creative Commons is not a
-    party to this document and has no duty or obligation with respect to
-    this CC0 or use of the Work.
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.


### PR DESCRIPTION
This pull request introduces several important changes to licensing and automation in the repository. The project license has been switched from CC0 to the BSD Zero Clause License. Additionally, the automation workflow for bumping the upstream coot commit has been simplified to target only the `beta` branch, and a new workflow has been added to automatically merge bot-generated PRs when all checks pass.

**Licensing:**
* Switched the project license from CC0 1.0 Universal to the BSD Zero Clause License in the `LICENSE` file.

**Automation and CI/CD workflows:**
* Added a new workflow `.github/workflows/auto-merge.yml` to automatically merge bot-generated PRs to the `beta` branch when all status checks succeed.
* Simplified `.github/workflows/upstream-coot-bump.yml` to only update the `beta` branch (removed matrix for `alpha`), including updating all relevant steps and PR metadata to reference `beta` only. [[1]](diffhunk://#diff-a7961f5b5f9b014ea4ae40e5376a39b98e0409a9e9f91dfea628afe6f1b6a9d9L18-R21) [[2]](diffhunk://#diff-a7961f5b5f9b014ea4ae40e5376a39b98e0409a9e9f91dfea628afe6f1b6a9d9L107-R110) [[3]](diffhunk://#diff-a7961f5b5f9b014ea4ae40e5376a39b98e0409a9e9f91dfea628afe6f1b6a9d9L126-R119)
* Minor cleanup in the schedule trigger for the bump workflow.
* Ensured trailing newline consistency in the workflow file.