### PR TITLE
Add new modules simdutf, fast_float and vte

### DIFF
--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -695,8 +695,8 @@ modules:
       - -Dsixel=true
     sources:
       - type: archive
-        url: https://gitlab.gnome.org/GNOME/vte/-/archive/0.82.4/vte-0.82.4.tar.gz
-        sha256: 005e0f48142c5f879dfa24105bc7f8c5030b2cf5d1b66831b3af29293bfb093b
+        url: https://gitlab.gnome.org/GNOME/vte/-/archive/0.84.1/vte-0.84.1.tar.gz
+        sha256: 9f73468982a339cd1eb942beb7d348a5564c9ed48473ad1690c791f8474916ec
         x-checker-data:
           type: anitya
           project-id: 10895

--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -667,8 +667,8 @@ modules:
     builddir: true
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
-      - -DFASTFLOAT_BUILD_TESTS=OFF
-      - -DFASTFLOAT_BUILD_BENCHMARKS=OFF
+      - -DFASTFLOAT_TEST=OFF
+      - -DFASTFLOAT_BENCHMARKS=OFF
     sources:
       - type: archive
         url: https://github.com/fastfloat/fast_float/archive/refs/tags/v8.2.10.tar.gz

--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -662,7 +662,7 @@ modules:
           stable-only: true
           url-template: https://github.com/simdutf/simdutf/archive/refs/tags/v$version.tar.gz
 
-  - name: fast-float
+  - name: fast_float
     buildsystem: cmake-ninja
     builddir: true
     config-opts:
@@ -689,8 +689,9 @@ modules:
       - -Dgir=false
       - -Dvapi=false
       - -Dfribidi=true
+      - -Dgnutls=true
       - -Dicu=true
-      - -Dsixel=true
+      - -D_systemd=true
     sources:
       - type: archive
         url: https://gitlab.gnome.org/GNOME/vte/-/archive/0.84.1/vte-0.84.1.tar.gz

--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -686,7 +686,7 @@ modules:
       - -Dgtk4=true
       - -Ddocs=false
       - -Dglade=false
-      - -Dgir=false
+      - -Dgir=true
       - -Dvapi=false
       - -Dfribidi=true
       - -Dgnutls=true

--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -689,9 +689,7 @@ modules:
       - -Dgir=false
       - -Dvapi=false
       - -Dfribidi=true
-      - -Dgnutls=true
       - -Dicu=true
-      - -Dsystemd=true
       - -Dsixel=true
     sources:
       - type: archive

--- a/io.github.pemsley.coot.yaml
+++ b/io.github.pemsley.coot.yaml
@@ -643,6 +643,66 @@ modules:
           stable-only: true
           url-template: https://github.com/Unidata/netcdf-c/archive/v$version.tar.gz
 
+  - name: simdutf
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DSIMDUTF_TESTS=OFF
+      - -DSIMDUTF_BENCHMARKS=OFF
+      - -DSIMDUTF_TOOLS=OFF
+      - -DBUILD_SHARED_LIBS=ON
+    sources:
+      - type: archive
+        url: https://github.com/simdutf/simdutf/archive/refs/tags/v9.0.0.tar.gz
+        sha256: fd2ce975f29809a975a8da8843cfb3a7265af3f71be548f199d23cf65e101764
+        x-checker-data:
+          type: anitya
+          project-id: 378662
+          stable-only: true
+          url-template: https://github.com/simdutf/simdutf/archive/refs/tags/v$version.tar.gz
+
+  - name: fast-float
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DFASTFLOAT_BUILD_TESTS=OFF
+      - -DFASTFLOAT_BUILD_BENCHMARKS=OFF
+    sources:
+      - type: archive
+        url: https://github.com/fastfloat/fast_float/archive/refs/tags/v8.2.10.tar.gz
+        sha256: 76f958dd97b1cf4d8862d1f0986a47d4bdfa8845252bae15ef0f40de3b95961f
+        x-checker-data:
+          type: anitya
+          project-id: 214353
+          stable-only: true
+          url-template: https://github.com/fastfloat/fast_float/archive/refs/tags/v$version.tar.gz
+
+  - name: vte
+    buildsystem: meson
+    config-opts:
+      - -Dgtk3=false
+      - -Dgtk4=true
+      - -Ddocs=false
+      - -Dglade=false
+      - -Dgir=false
+      - -Dvapi=false
+      - -Dfribidi=true
+      - -Dgnutls=true
+      - -Dicu=true
+      - -Dsystemd=true
+      - -Dsixel=true
+    sources:
+      - type: archive
+        url: https://gitlab.gnome.org/GNOME/vte/-/archive/0.82.4/vte-0.82.4.tar.gz
+        sha256: 005e0f48142c5f879dfa24105bc7f8c5030b2cf5d1b66831b3af29293bfb093b
+        x-checker-data:
+          type: anitya
+          project-id: 10895
+          stable-only: true
+          url-template: https://gitlab.gnome.org/GNOME/vte/-/archive/$version/vte-$version.tar.gz
+
   - name: coot
     buildsystem: autotools
     config-opts:
@@ -659,6 +719,7 @@ modules:
       - --with-guile
       - --with-sound
       - --with-sqlite3
+      - --with-vte
       - --disable-dependency-tracking
       - --disable-silent-rules
       - --enable-shared


### PR DESCRIPTION
This pull request adds three new dependencies and updates the build configuration for the `coot` module in `io.github.pemsley.coot.yaml`. The main changes are the addition of the `simdutf`, `fast_float`, and `vte` modules, and enabling VTE support in the `coot` build.

**New dependencies:**

* Added the `simdutf` module, which is built with CMake and disables tests, benchmarks, and tools for a minimal build.
* Added the `fast_float` module, also built with CMake, with tests and benchmarks disabled.
* Added the `vte` module, built with Meson, configured to use GTK4 and several features enabled or disabled for a streamlined build.

**Build configuration updates:**

* Updated the `coot` module's configuration options to include `--with-vte`, enabling VTE support.